### PR TITLE
allowing to execute as "python -m s3conf", unique entrypoint

### DIFF
--- a/s3conf/__main__.py
+++ b/s3conf/__main__.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from .client import main as _main
+
+
+def main():
+    # fixing the name of the entrypoint when the module is executed as
+    # python -m s3conf
+    entrypoint_name = os.path.basename(sys.argv[0])
+    if entrypoint_name == '__main__.py':
+        entrypoint_name = 's3conf'
+
+    _main(prog_name=entrypoint_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/s3conf/client.py
+++ b/s3conf/client.py
@@ -345,7 +345,3 @@ def unset(section, value):
         env_vars.unset(value)
     except exceptions.EnvfilePathNotDefinedError:
         raise exceptions.EnvfilePathNotDefinedUsageError()
-
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,6 @@ setup(
     ],
     entry_points='''
     [console_scripts]
-    s3conf=s3conf.client:main
+    s3conf=s3conf.__main__:main
     ''',
 )


### PR DESCRIPTION
- adding `__main__.py` to `s3conf` module in order to be able to execute `python -m s3conf`
- unique entrypoint