### PR TITLE
S3conf init

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ click-log~=0.2.1
 pytest~=3.6.3
 pytest-pythonpath~=0.7.2
 pytest-cov~=2.5.1
-configobj~==5.0.6
+configobj~=5.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ click-log~=0.2.1
 pytest~=3.6.3
 pytest-pythonpath~=0.7.2
 pytest-cov~=2.5.1
+configobj~==5.0.6

--- a/s3conf/client.py
+++ b/s3conf/client.py
@@ -325,3 +325,24 @@ def unset(section, value):
         env_vars.unset(value)
     except exceptions.EnvfilePathNotDefinedError:
         raise exceptions.EnvfilePathNotDefinedUsageError()
+
+
+@main.command('init')
+@click.argument('section')
+@click.argument('remote-file')
+def unset(section, remote_file):
+    """
+    Creates the .s3conf config folder and .s3conf/config config file
+    with the provided section name and configuration file. It is a very
+    basic config file. Manually edit it in order to add credentials. E.g.:
+
+    s3conf init development s3://my-project/development.env
+    """
+    if not remote_file.startswith('s3://'):
+        raise UsageError('REMOTE_FILE must be a S3-like path. E.g.:\n\n'
+                         's3conf init development s3://my-project/development.env')
+    logger.debug('Running init command')
+    config_file_path = os.path.join(os.getcwd(), '.s3conf', 'config')
+    config_file = config.ConfigFileResolver(config_file_path, section=section)
+    config_file.set('S3CONF', remote_file)
+    config_file.save()

--- a/s3conf/storages.py
+++ b/s3conf/storages.py
@@ -86,6 +86,8 @@ class S3Storage(BaseStorage):
         except ClientError as e:
             if e.response['Error']['Code'] == 'BucketAlreadyExists':
                 bucket = self.s3.Bucket(bucket)
+            else:
+                raise e
         bucket.upload_fileobj(f, path_target)
 
     def list(self, path):

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'click>=6.7',
         'python-editor>=1.0.3',
         'click-log>=0.2.1',
+        'configobj>=5.0.6'
     ],
     python_requires='~=3.5',
     setup_requires=[],


### PR DESCRIPTION
- Adding 's3conf init' command to create a basic config file
- Using `configobj` to preserve config file comments