### PR TITLE
Fix readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ sudo curl -L "https://github.com/sbneto/s3conf/releases/download/0.9.6/s3conf-$(
 sudo chmod 755 /usr/local/bin/s3conf
 ```
 
-If it is not available for your platform, you can use pip:
+If it is not available for your platform, you can use pip to install with one or both extras (aws and gcp):
 
 ```python
-pip install s3conf
+pip install s3conf[aws,gcp]
 ```
 
 # Usage
@@ -47,10 +47,13 @@ S3CONF = s3://my-dev-bucket/dev-env/myfile.env
 
 ### S3 Credentials
 
-If you have a `aws-cli` working, `s3conf` will user your default credentials. This should already be 
-enough to get you started.
+If you have a `aws-cli` working, `s3conf` will user your default credentials. This can be done with:
 
-This is also true for GCP:
+```bash
+aws configure
+```
+
+Similarly, `s3conf` looks for default gcp credentials.
 
 ```bash
 gcloud auth application-default login

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ S3CONF = s3://my-dev-bucket/dev-env/myfile.env
 If you have a `aws-cli` working, `s3conf` will user your default credentials. This should already be 
 enough to get you started.
 
+This is also true for GCP:
+
+```bash
+gcloud auth application-default login
+```
+
 #### Manually setting the credentials
 
 If you do not have a configured aws-cli, the client will search for these authentication variables in

--- a/s3conf/storage/files.py
+++ b/s3conf/storage/files.py
@@ -31,10 +31,11 @@ class File:
 
     # IOBase
     def flush(self) -> None:
-        self.file.flush()
-        self._buffer.seek(0)
-        logger.debug('Writing buffer to %s', self.name)
-        self.storage.write(self._buffer, self.name)
+        if self.file.writable():
+            self.file.flush()
+            self._buffer.seek(0)
+            logger.debug('Writing buffer to %s', self.name)
+            self.storage.write(self._buffer, self.name)
 
     # IOBase
     def close(self) -> None:


### PR DESCRIPTION
`flush` tried to write to read-only files. As per [documentation](https://docs.python.org/3/library/io.html#io.IOBase.flush), it should do nothing when it is a read-only.