### PR TITLE
Fixing gcp hashes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ configobj~=5.0.6
 google-cloud-storage~=1.15.0
 bumpversion~=0.5.3
 requests~=2.21.0
+crc32c~=1.7

--- a/s3conf/client.py
+++ b/s3conf/client.py
@@ -96,7 +96,7 @@ def env(section, map_files, phusion, phusion_path, quiet, edit, create):
         conf = s3conf.S3Conf(settings=settings)
 
         if edit:
-            conf.edit(create=create)
+            conf.edit()
         else:
             with conf.get_envfile() as env_file:
                 env_vars = env_file.as_dict()
@@ -124,8 +124,8 @@ def add(section, local_path):
     try:
         settings = config.Settings(section=section)
         local_path = Path(local_path).resolve().relative_to(settings.root_folder)
-        remote_path = os.path.join(os.path.dirname(settings.environment_file_path), 'files', local_path)
-        settings.add_mapping(remote_path, local_path)
+        remote_path = os.path.join(os.path.dirname(settings.environment_file_path), 'files', str(local_path))
+        settings.add_mapping(remote_path, str(local_path))
         config_file = config.ConfigFileResolver(settings.config_file, section=section)
         config_file.set('S3CONF_MAP', settings.serialize_mappings())
         config_file.save()
@@ -143,7 +143,7 @@ def rm(section, local_path):
     try:
         settings = config.Settings(section=section)
         local_path = Path(local_path).resolve().relative_to(settings.root_folder)
-        settings.rm_mapping(local_path)
+        settings.rm_mapping(str(local_path))
         config_file = config.ConfigFileResolver(settings.config_file, section=section)
         config_file.set('S3CONF_MAP', settings.serialize_mappings())
         config_file.save()
@@ -243,7 +243,7 @@ def set_variable(section, value, create):
         settings = config.Settings(section=section)
         conf = s3conf.S3Conf(settings=settings)
 
-        with conf.get_envfile(create=create) as env_vars:
+        with conf.get_envfile(mode='r+') as env_vars:
             env_vars.set(value)
     except EnvfilePathNotDefinedError:
         raise EnvfilePathNotDefinedUsageError()
@@ -268,7 +268,7 @@ def unset_variable(section, value):
         settings = config.Settings(section=section)
         conf = s3conf.S3Conf(settings=settings)
 
-        with conf.get_envfile() as env_vars:
+        with conf.get_envfile(mode='r+') as env_vars:
             env_vars.unset(value)
     except EnvfilePathNotDefinedError:
         raise EnvfilePathNotDefinedUsageError()

--- a/s3conf/client.py
+++ b/s3conf/client.py
@@ -84,7 +84,7 @@ def main(ctx, edit):
 @click.option('--create',
               '-c',
               is_flag=True,
-              help='When trying to edit a file, create it if it does not exist.')
+              help='Create the remote environment file if it does not exist.')
 def env(section, map_files, phusion, phusion_path, quiet, edit, create):
     """
     Reads the file defined by the S3CONF variable and output its contents to stdout. Logs are printed to stderr.
@@ -95,8 +95,11 @@ def env(section, map_files, phusion, phusion_path, quiet, edit, create):
         settings = config.Settings(section=section)
         conf = s3conf.S3Conf(settings=settings)
 
+        if create:
+            conf.create_envfile()
+
         if edit:
-            conf.edit()
+            conf.edit_envfile()
         else:
             with conf.get_envfile() as env_file:
                 env_vars = env_file.as_dict()
@@ -223,11 +226,7 @@ def exec_command(ctx, section, command, map_files):
 @click.argument('section', cls=SectionArgument)
 @click.argument('value',
                 required=False)
-@click.option('--create',
-              '-c',
-              is_flag=True,
-              help='When trying to set a variable, create the file if it does not exist.')
-def set_variable(section, value, create):
+def set_variable(section, value):
     """
     Set value of a variable in an environment file for the given section.
     If the variable is already defined, its value is replaced, otherwise, it is added to the end of the file.

--- a/s3conf/s3conf.py
+++ b/s3conf/s3conf.py
@@ -96,11 +96,22 @@ class S3Conf:
         return hashes
 
     def get_envfile(self, mode='r'):
-        logger.info('Loading configs from {}'.format(self.settings.environment_file_path))
+        logger.info('Loading configs from %s', self.settings.environment_file_path)
         remote_storage = self.storages.storage(self.settings.environment_file_path)
         _, _, path = partition_path(self.settings.environment_file_path)
         return EnvFile.from_file(remote_storage.open(path, mode=mode))
 
-    def edit(self):
+    def edit_envfile(self):
         with self.get_envfile(mode='r+') as envfile:
             envfile.edit()
+
+    def create_envfile(self):
+        logger.info('Trying to create envifile %s', self.settings.environment_file_path)
+        remote_storage = self.storages.storage(self.settings.environment_file_path)
+        _, _, path = partition_path(self.settings.environment_file_path)
+        envfile_exist = bool(list(remote_storage.list(path)))
+        if envfile_exist:
+            logger.warning('%s already exist', self.settings.environment_file_path)
+        else:
+            with self.get_envfile(mode='w') as _:
+                pass

--- a/s3conf/storages.py
+++ b/s3conf/storages.py
@@ -157,6 +157,8 @@ class StorageMapper:
         for source_hash, source_file, target_file in self.expand_path(source_path, target_path):
             if target_file not in target_hashes or target_hashes[target_file] != source_hash:
                 to_copy.append((source_hash, source_file, target_file))
+            else:
+                logger.info('Skipping (no changes): %s -> %s', source_file, target_file)
             final_state.append((source_hash, source_file, target_file))
 
         return final_state, to_copy

--- a/s3conf/storages.py
+++ b/s3conf/storages.py
@@ -217,14 +217,10 @@ class EnvFile(BaseFile):
         return obj
 
     def as_dict(self):
-        env_dict = {}
-        try:
-            self.seek(0)
-            lines = self.read().splitlines()
-            lines = [line for line in lines if line and not line.startswith('#') and '=' in line]
-            env_dict = dict(parse_env_var(line) for line in lines)
-        except FileNotFoundError:
-            pass
+        self.seek(0)
+        lines = self.read().splitlines()
+        lines = [line for line in lines if line and not line.startswith('#') and '=' in line]
+        env_dict = dict(parse_env_var(line) for line in lines)
         return env_dict
 
     def set(self, value):

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         ],
         'gcp': [
             'google-cloud-storage>=1.15.0',
+            'crc32c>=1.7',
         ],
     },
     classifiers=[


### PR DESCRIPTION
- Hash check should work for gcp now
- Re-organizing some internal interfaces
- Pathlib is nice, but it was hard to track when an object (or a dict index) was a `Path` or a `str`. Still using it, but now returns and function call always use str